### PR TITLE
Added null-coalescing check for published date

### DIFF
--- a/models.php
+++ b/models.php
@@ -22,8 +22,8 @@ class Webmention {
 class WebmentionStore {
 	public function add_mention($mention) {
 		$file_path = APP_DATA_DIR . DIRECTORY_SEPARATOR . $mention->mentionId . ".json";
-        $mention->data['published'] = $mention->data['published'] ?? $mention->data['wm-received'];
-        file_put_contents(
+		$mention->data['published'] = $mention->data['published'] ?? $mention->data['wm-received'];
+		file_put_contents(
 			$file_path, 
 			json_encode($mention->data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
 		);

--- a/models.php
+++ b/models.php
@@ -22,7 +22,8 @@ class Webmention {
 class WebmentionStore {
 	public function add_mention($mention) {
 		$file_path = APP_DATA_DIR . DIRECTORY_SEPARATOR . $mention->mentionId . ".json";
-		file_put_contents(
+        $mention->data['published'] = $mention->data['published'] ?? $mention->data['wm-received'];
+        file_put_contents(
 			$file_path, 
 			json_encode($mention->data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
 		);


### PR DESCRIPTION
This small adjustment checks that there is a published date set on the incoming webmention.

If `published` is `null`, then it is set to the same datestamp as `wm-received`.

This deals with errors created in Hugo where `"published": null` causes a failure to build.